### PR TITLE
Add RoutingOptions to payment requests

### DIFF
--- a/Craftgate/Request/CreateDepositPaymentRequest.cs
+++ b/Craftgate/Request/CreateDepositPaymentRequest.cs
@@ -13,5 +13,6 @@ namespace Craftgate.Request
         public string PosAlias { get; set; }
         public string ClientIp { get; set; }
         public Card Card { get; set; }
+        public RoutingOptions RoutingOptions { get; set; }
     }
 }

--- a/Craftgate/Request/CreatePaymentRequest.cs
+++ b/Craftgate/Request/CreatePaymentRequest.cs
@@ -21,6 +21,7 @@ namespace Craftgate.Request
         public string BankOrderId { get; set; }
         public string ClientIp { get; set; }
         public Card Card { get; set; }
+        public RoutingOptions RoutingOptions { get; set; }
         public FraudCheckParameters FraudParams { get; set; }
         public IList<PaymentItem> Items { get; set; }
         public Dictionary<string, object> AdditionalParams { get; set; }

--- a/Craftgate/Request/Dto/RoutingOptions.cs
+++ b/Craftgate/Request/Dto/RoutingOptions.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Craftgate.Request.Dto
+{
+    public class RoutingOptions
+    {
+        public OrderingRule? OrderingRule { get; set; }
+        public IList<string> PosAliases { get; set; }
+    }
+
+    public enum OrderingRule
+    {
+        ON_US,
+        LOW_COMMISSION_RATE,
+        IN_ORDER
+    }
+}

--- a/Craftgate/Request/InitCheckoutPaymentRequest.cs
+++ b/Craftgate/Request/InitCheckoutPaymentRequest.cs
@@ -35,6 +35,7 @@ namespace Craftgate.Request
         public long? Ttl { get; set; }
         public IList<CustomInstallment> CustomInstallments { get; set; }
         public IList<PaymentItem> Items { get; set; }
+        public RoutingOptions RoutingOptions { get; set; }
         public FraudCheckParameters FraudParams { get; set; }
         public Dictionary<string, object> AdditionalParams { get; set; }
         public Dictionary<string, List<CustomInstallment>> CardBrandInstallments { get; set; }


### PR DESCRIPTION
## Summary
Add RoutingOptions DTO to payment requests to allow clients to specify routing preferences.

## Changes
- Add `RoutingOptions` class with `OrderingRule` enum (ON_US, LOW_COMMISSION_RATE, IN_ORDER) and `PosAliases` property
- Add `RoutingOptions` property to:
  - `CreatePaymentRequest`
  - `CreateDepositPaymentRequest`
  - `InitThreeDSPaymentRequest` (inherited from CreatePaymentRequest)
  - `InitCheckoutPaymentRequest`

## Technical Details
- `OrderingRule` enum values: ON_US, LOW_COMMISSION_RATE, IN_ORDER
- `PosAliases`: Optional list of POS aliases for routing configuration
- All properties are optional to maintain backward compatibility

## Test Plan
- [ ] Verify compilation
- [ ] Test payment request creation with RoutingOptions
- [ ] Test backward compatibility (requests without RoutingOptions)
- [ ] Verify serialization/deserialization